### PR TITLE
mod_turnitintool Trigger an event on assignment submission

### DIFF
--- a/turnitintool/db/events.php
+++ b/turnitintool/db/events.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @package   turnitintool
+ * @copyright 2012 Lancaster University
+ */
+
+$handlers = array();
+
+/* List of events thrown from turnitintool module
+
+assessable_submitted
+    ->modulename     = 'turnitintool';
+    ->cmid           = // The cmid of the assign.
+    ->itemid         = // The submission id of the user submission (recorded in mdl_turnitintool_submissions).
+    ->courseid       = // The course id of the course the assign belongs to.
+    ->userid         = // The user id that the attempt belongs to.
+
+*/

--- a/turnitintool/lib.php
+++ b/turnitintool/lib.php
@@ -5838,7 +5838,7 @@ function turnitintool_tempfile($suffix) {
  * @param object $submission The submission object for this submission
  */
 function turnitintool_upload_submission($cm,$turnitintool,$submission) {
-    global $CFG;
+    global $CFG, $USER;
 
     if (!$course = turnitintool_get_record('course','id',$turnitintool->course)) {
         turnitintool_print_error('coursegeterror','turnitintool',NULL,NULL,__FILE__,__LINE__);
@@ -5961,6 +5961,19 @@ function turnitintool_upload_submission($cm,$turnitintool,$submission) {
         turnitintool_print_error('submissionupdateerror','turnitintool',NULL,NULL,__FILE__,__LINE__);
         exit();
     }
+
+    if (function_exists('events_trigger')) {
+        // Trigger assessable_submitted event on submission.
+        $eventdata = new stdClass();
+        $eventdata->modulename   = 'turnitintool';
+        $eventdata->cmid         = $cm->id;
+        $eventdata->itemid       = $submission->id;
+        $eventdata->courseid     = $course->id;
+        $eventdata->userid       = $USER->id;
+        events_trigger('assessable_submitted', $eventdata);
+    }
+
+
     $tii->endSession();
 
     if (has_capability('mod/turnitintool:grade', get_context_instance(CONTEXT_MODULE, $cm->id))) {


### PR DESCRIPTION
This allows developers to hook in and perform actions when a TII
submissions is submitted.

This event follows the same naming scheme as discussed in MDL-35710.

Sorry - just remembered that I'd not included the events definition and that Moodle 1.9 doesn't support events. This should only attempt to trigger the events on supporting systems (e.g. Moodle 2).
