### PR TITLE
Fixed "table AS" incompatibility with Oracle databases

### DIFF
--- a/turnitintool/filestable.php
+++ b/turnitintool/filestable.php
@@ -44,26 +44,26 @@ $sQuery = 'SELECT
     cs.id AS course,
     sb.submission_filename AS filename,
     sb.submission_objectid AS objectid
-FROM '.$CFG->prefix.'files AS fl
+FROM '.$CFG->prefix.'files fl
 LEFT JOIN
-    '.$CFG->prefix.'turnitintool_submissions AS sb ON fl.itemid = sb.id
+    '.$CFG->prefix.'turnitintool_submissions sb ON fl.itemid = sb.id
 LEFT JOIN
-    '.$CFG->prefix.'user AS us ON fl.userid = us.id
+    '.$CFG->prefix.'user us ON fl.userid = us.id
 LEFT JOIN
-    '.$CFG->prefix.'course_modules AS cm ON fl.contextid = cm.id AND cm.module = '.$param_module.'
+    '.$CFG->prefix.'course_modules cm ON fl.contextid = cm.id AND cm.module = '.$param_module.'
 LEFT JOIN
-    '.$CFG->prefix.'turnitintool AS tu ON cm.instance = tu.id
+    '.$CFG->prefix.'turnitintool tu ON cm.instance = tu.id
 LEFT JOIN
-    '.$CFG->prefix.'course AS cs ON tu.course = cs.id
+    '.$CFG->prefix.'course cs ON tu.course = cs.id
 WHERE
     fl.component = \'mod_turnitintool\' AND fl.filesize != 0';
 
 $sCountQuery = 'SELECT
     fl.id AS id
 FROM
-    '.$CFG->prefix.'files AS fl
+    '.$CFG->prefix.'files fl
 LEFT JOIN
-    '.$CFG->prefix.'turnitintool_submissions AS sb ON fl.itemid = sb.id
+    '.$CFG->prefix.'turnitintool_submissions sb ON fl.itemid = sb.id
 WHERE
     fl.component = "mod_turnitintool" AND fl.filesize != 0';
 

--- a/turnitintool/lib.php
+++ b/turnitintool/lib.php
@@ -3321,17 +3321,17 @@ SELECT
     s.submission_unanon AS submission_unanon,
     s.submission_unanonreason AS submission_unanonreason,
     s.submission_transmatch AS submission_transmatch
-FROM {turnitintool_submissions} AS s
+FROM {turnitintool_submissions} s
     LEFT JOIN
-        {user} AS u ON u.id = s.userid
+        {user} u ON u.id = s.userid
     LEFT JOIN
-        {turnitintool_parts} AS p ON p.id = s.submission_part
+        {turnitintool_parts} p ON p.id = s.submission_part
     LEFT JOIN
-        {turnitintool} AS t ON t.id = p.turnitintoolid
+        {turnitintool} t ON t.id = p.turnitintoolid
     LEFT JOIN
-        {turnitintool_users} AS tu ON u.id = tu.userid
+        {turnitintool_users} tu ON u.id = tu.userid
     LEFT JOIN
-        {user_info_data} AS ud ON u.id = ud.userid AND ud.fieldid = $usifieldid
+        {user_info_data} ud ON u.id = ud.userid AND ud.fieldid = $usifieldid
 WHERE
     s.turnitintoolid = ".$turnitintool->id."
 ORDER BY s.submission_grade DESC

--- a/turnitintool/userlinktable.php
+++ b/turnitintool/userlinktable.php
@@ -32,14 +32,14 @@ $sQuery = 'SELECT
     mu.firstname AS firstname,
     mu.lastname AS lastname,
     mu.email AS email
-FROM '.$CFG->prefix.'turnitintool_users AS tu
+FROM '.$CFG->prefix.'turnitintool_users tu
 LEFT JOIN
-    '.$CFG->prefix.'user AS mu ON tu.userid = mu.id';
+    '.$CFG->prefix.'user mu ON tu.userid = mu.id';
 
 $sCountQuery = 'SELECT
     tu.id AS id
 FROM
-    '.$CFG->prefix.'turnitintool_users AS tu';
+    '.$CFG->prefix.'turnitintool_users tu';
 
 $param_sortcol[0] = optional_param('iSortCol_0', null, PARAM_INT);  // sortcol
 $param_sortingcols = optional_param('iSortingCols', 0, PARAM_INT);  // sortingcols


### PR DESCRIPTION
Oracle database does not support the use of "AS" in table aliases in queries.
For instance:
SELECT foo
FROM bar AS baz

yields the following error in Oracle:
ORA-00933: SQL command not properly ended

The solution is to omit the "AS". This was done in several locations affecting
the following functionality:
- "Unlink Users" administration link
- "Files" administration link
- "Submission Inbox" in-assignment tab
