### PR TITLE
Fixed M27-M28 jquery conflict.

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -10,15 +10,26 @@ if ($ADMIN->fulltree) {
     require_once($CFG->dirroot.'/mod/turnitintool/lib.php');
     require_once($CFG->dirroot.'/mod/turnitintool/version.php');
 
-    if (isset($PAGE) AND is_callable(array($PAGE->requires, 'js'))) { // Are we using new moodle or old?
-        $jsurl = new moodle_url($CFG->wwwroot.'/mod/turnitintool/scripts/jquery-1.11.0.min.js');
+    $jquery = $CFG->wwwroot.'/mod/turnitintool/scripts/jquery-1.11.0.min.js';
+    $tool = $CFG->wwwroot.'/mod/turnitintool/scripts/turnitintool.js';
+
+    if (isset($PAGE) AND is_callable(array('page_requirements_manager', 'jquery'))) {
+        // Use built-in jquery, if it's available.
+        $PAGE->requires->jquery();
+
+        $jsurl = new moodle_url($tool);
+        $PAGE->requires->js($jsurl,true);
+    } else if (isset($PAGE) AND is_callable(array($PAGE->requires, 'js'))) {
+        // Use "new" moodle way, if possible.
+        $jsurl = new moodle_url($jquery);
         $PAGE->requires->js($jsurl,true);
 
-        $jsurl = new moodle_url($CFG->wwwroot.'/mod/turnitintool/scripts/turnitintool.js');
+        $jsurl = new moodle_url($tool);
         $PAGE->requires->js($jsurl,true);
     } else {
-        require_js($CFG->wwwroot.'/mod/turnitintool/scripts/jquery-1.11.0.min.js');
-        require_js($CFG->wwwroot.'/mod/turnitintool/scripts/turnitintool.js');
+        // Try the old way, if nothing else works.
+        require_js($jquery);
+        require_js($tool);
     }
 
     $param_updatecheck=optional_param('updatecheck',null,PARAM_CLEAN);


### PR DESCRIPTION
Hi, this patch fixes a conflict that can occur when another plugin also wants to use jQuery on the same page as the Turnitintool module. We have some clients that want to use V1 in Moodle 27 and 28, and some of them have other plugins that also wants to use jQuery. When that happens, the the multiple different versions of jQuery that have been loaded break jQuery for every plugin.

Resubmitted to the develop branch as requested.